### PR TITLE
Document availability in Debian 10+

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Packages in this section are not part of the official repositories. If you have 
 | Arch Linux | Josip Ponjavic | [materia-kde-git](https://aur.archlinux.org/packages/materia-kde-git) <sup>AUR</sup> |
 | openSUSE   | Konstantin Voinov | [materia-kde](https://software.opensuse.org/download.html?project=home:kill_it&package=materia-kde) <sup>OBS [[link](https://build.opensuse.org/package/show/home:kill_it/materia-kde)]</sub> |
 | Fedora     | Laurent Trequier | [materia-kde](https://copr.fedorainfracloud.org/coprs/tcg/themes/) <sup>copr</sup> |
-| Debian 11+ | Debian Desktop Themes Team | [materia-kde](https://packages.debian.org/source/bullseye/materia-kde) |
+| Debian 10+ | Debian Desktop Themes Team | [materia-kde](https://tracker.debian.org/pkg/materia-kde) |
 
 **NOTE:** If you maintainer and want be in the list please create an issue or send a pull request.
 


### PR DESCRIPTION
Update link to Debian package of materia-kde so that all available versions in Debian 10 and Debian 11 are listed.