### PR TITLE
Update package information for Fedora

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Packages in this section are not part of the official repositories. If you have 
 | Arch Linux | Bruno Pagani | `sudo pacman -S materia-kde kvantum-theme-materia` <sup>[[link](https://www.archlinux.org/packages/community/any/materia-kde/)]</sup> |
 | Arch Linux | Josip Ponjavic | [materia-kde-git](https://aur.archlinux.org/packages/materia-kde-git) <sup>AUR</sup> |
 | openSUSE   | Konstantin Voinov | [materia-kde](https://software.opensuse.org/download.html?project=home:kill_it&package=materia-kde) <sup>OBS [[link](https://build.opensuse.org/package/show/home:kill_it/materia-kde)]</sub> |
-| Fedora     | Laurent Trequier | [materia-kde](https://copr.fedorainfracloud.org/coprs/tcg/themes/) <sup>copr</sup> |
+| Fedora     | Robert-André Mauchin | [materia-kde](https://src.fedoraproject.org/rpms/materia-kde) |
 | Debian 10+ | Debian Desktop Themes Team | [materia-kde](https://tracker.debian.org/pkg/materia-kde) |
 
 **NOTE:** If you maintainer and want be in the list please create an issue or send a pull request.


### PR DESCRIPTION
The COPR repo by Laurent Tréguier has been discontinued. Materia-kde has now been added to Fedora official repo by Robert-André Mauchin.

The materia-kde package is currently in testing phase but should be available in a couple of weeks. (I also package arc-kde and papirus-icon-theme for Fedora).