### PR TITLE
Fix deprecated code warning

### DIFF
--- a/sddm/themes/materia-dark/Main.qml
+++ b/sddm/themes/materia-dark/Main.qml
@@ -30,10 +30,10 @@ Rectangle {
 
     Connections {
         target: sddm
-        onLoginSucceeded: {
+        function onLoginSucceeded() {
 
         }
-        onLoginFailed: {
+        function onLoginFailed() {
             password.placeholderText = textConstants.loginFailed
             password.placeholderTextColor = "#f44336"
             password.text = ""

--- a/sddm/themes/materia-light/Main.qml
+++ b/sddm/themes/materia-light/Main.qml
@@ -30,10 +30,10 @@ Rectangle {
 
     Connections {
         target: sddm
-        onLoginSucceeded: {
+        function onLoginSucceeded() {
 
         }
-        onLoginFailed: {
+        function onLoginFailed() {
             password.placeholderText = textConstants.loginFailed
             password.placeholderTextColor = "#f44336"
             password.text = ""

--- a/sddm/themes/materia/Main.qml
+++ b/sddm/themes/materia/Main.qml
@@ -30,10 +30,10 @@ Rectangle {
 
     Connections {
         target: sddm
-        onLoginSucceeded: {
+        function onLoginSucceeded() {
 
         }
-        onLoginFailed: {
+        function onLoginFailed() {
             password.placeholderText = textConstants.loginFailed
             password.placeholderTextColor = "#f44336"
             password.text = ""


### PR DESCRIPTION
Fixes `file:///usr/share/sddm/themes/materia-dark/Main.qml:31:5: QML Connections: Implicitly defined onFoo properties in Connections are deprecated. Use this syntax instead: function onFoo(<arguments>) { ... }`