### PR TITLE
Make subsequent showings of the KScreenLocker Theme's UI eat the initial input

### DIFF
--- a/plasma/look-and-feel/com.github.varlesh.materia/contents/lockscreen/LockScreenUi.qml
+++ b/plasma/look-and-feel/com.github.varlesh.materia/contents/lockscreen/LockScreenUi.qml
@@ -141,7 +141,11 @@ PlasmaCore.ColorScope {
             if (blockUI) {
                 fadeoutTimer.running = false;
             } else if (uiVisible) {
+                mainBlock.mainPasswordBox.forceActiveFocus();
                 fadeoutTimer.restart();
+            }
+            if (!uiVisible) {
+                lockScreenRoot.forceActiveFocus();
             }
             if (!calledUnlock) {
                 calledUnlock = true


### PR DESCRIPTION
Basically fixes https://github.com/PapirusDevelopmentTeam/materia-kde/issues/149 in the way it sounds like was intended by taking focus away from the input field whenever the UI's hidden (and refocusing when shown). This makes the first input after the UI hides never input into the password field (unless shown, then input).

It's not the most perfect way to achieve this, but it does the job very well.