### PR TITLE
[SDDM] Fix user icon missing

### DIFF
--- a/sddm/themes/materia-dark/Main.qml
+++ b/sddm/themes/materia-dark/Main.qml
@@ -252,7 +252,7 @@ Rectangle {
                         layer.effect: OpacityMask {
                             maskSource: mask
                         }
-                        source: "/home/" + user.currentText + "/.face.icon"
+                        source: "/var/lib/AccountsService/icons/" + user.currentText
                         onStatusChanged: {
                             if (status == Image.Error)
                                 return source = "images/.face.icon"
@@ -283,7 +283,7 @@ Rectangle {
                             ulistview.currentIndex = index
                             user.popup.close()
                             ava.source = ""
-                            ava.source = "/home/" + user.currentText + "/.face.icon"
+                            ava.source = "/var/lib/AccountsService/icons/" + user.currentText
                         }
                     }
                     popup: Popup {

--- a/sddm/themes/materia-light/Main.qml
+++ b/sddm/themes/materia-light/Main.qml
@@ -252,7 +252,7 @@ Rectangle {
                         layer.effect: OpacityMask {
                             maskSource: mask
                         }
-                        source: "/home/" + user.currentText + "/.face.icon"
+                        source: "/var/lib/AccountsService/icons/" + user.currentText
                         onStatusChanged: {
                             if (status == Image.Error)
                                 return source = "images/.face.icon"
@@ -283,7 +283,7 @@ Rectangle {
                             ulistview.currentIndex = index
                             user.popup.close()
                             ava.source = ""
-                            ava.source = "/home/" + user.currentText + "/.face.icon"
+                            ava.source = "/var/lib/AccountsService/icons/" + user.currentText
                         }
                     }
                     popup: Popup {

--- a/sddm/themes/materia/Main.qml
+++ b/sddm/themes/materia/Main.qml
@@ -252,7 +252,7 @@ Rectangle {
                         layer.effect: OpacityMask {
                             maskSource: mask
                         }
-                        source: "/home/" + user.currentText + "/.face.icon"
+                        source: "/var/lib/AccountsService/icons/" + user.currentText
                         onStatusChanged: {
                             if (status == Image.Error)
                                 return source = "images/.face.icon"
@@ -283,7 +283,7 @@ Rectangle {
                             ulistview.currentIndex = index
                             user.popup.close()
                             ava.source = ""
-                            ava.source = "/home/" + user.currentText + "/.face.icon"
+                            ava.source = "/var/lib/AccountsService/icons/" + user.currentText
                         }
                     }
                     popup: Popup {


### PR DESCRIPTION
According to https://github.com/sddm/sddm/blob/develop/src/greeter/UserModel.cpp#L139, SDDM detects icons in `/var/lib/AccountsService/icons/` without configuration, and Plasma no longer creates the files in `$HOME/`.  
This PR basically fixes https://github.com/PapirusDevelopmentTeam/materia-kde/issues/137.