### PR TITLE
KF6 Port: Migrate metadata to json files

### DIFF
--- a/aurorae/themes/Materia-Dark/metadata.json
+++ b/aurorae/themes/Materia-Dark/metadata.json
@@ -1,0 +1,17 @@
+{
+    "KPlugin": {
+        "Authors": [
+            {
+                "Email": "varlesh@gmail.com",
+                "Name": "Alexey Varfolomeev"
+            }
+        ],
+        "Category": "",
+        "Dependencies": [],
+        "EnabledByDefault": true,
+        "Id": "Materia-Dark",
+        "License": "GPLv3",
+        "Name": "Materia Dark",
+        "Version": "1.0"
+    }
+}

--- a/aurorae/themes/Materia-Light/metadata.json
+++ b/aurorae/themes/Materia-Light/metadata.json
@@ -1,0 +1,17 @@
+{
+    "KPlugin": {
+        "Authors": [
+            {
+                "Email": "varlesh@gmail.com",
+                "Name": "Alexey Varfolomeev"
+            }
+        ],
+        "Category": "",
+        "Dependencies": [],
+        "EnabledByDefault": true,
+        "Id": "Materia-Light",
+        "License": "GPLv3",
+        "Name": "Materia Light",
+        "Version": "1.0"
+    }
+}

--- a/aurorae/themes/Materia/metadata.json
+++ b/aurorae/themes/Materia/metadata.json
@@ -1,0 +1,17 @@
+{
+    "KPlugin": {
+        "Authors": [
+            {
+                "Email": "varlesh@gmail.com",
+                "Name": "Alexey Varfolomeev"
+            }
+        ],
+        "Category": "",
+        "Dependencies": [],
+        "EnabledByDefault": true,
+        "Id": "Materia",
+        "License": "GPLv3",
+        "Name": "Materia",
+        "Version": "1.0"
+    }
+}

--- a/plasma/desktoptheme/Materia-Color/metadata.json
+++ b/plasma/desktoptheme/Materia-Color/metadata.json
@@ -1,0 +1,19 @@
+{
+    "KPlugin": {
+        "Authors": [
+            {
+                "Email": "varlesh@gmail.com",
+                "Name": "Alexey Varfolomeev"
+            }
+        ],
+        "Category": "",
+        "Description": "Materia KDE customization",
+        "EnabledByDefault": true,
+        "Id": "Materia-Color",
+        "License": "GPLv3",
+        "Name": "Materia Color",
+        "Version": "20220823",
+        "Website": "https://github.com/PapirusDevelopmentTeam/materia-kde"
+    },
+    "X-Plasma-APIVersion": "2"
+}

--- a/plasma/desktoptheme/Materia-Color/plasmarc
+++ b/plasma/desktoptheme/Materia-Color/plasmarc
@@ -1,0 +1,5 @@
+[ContrastEffect]
+enabled=false
+contrast=0.2
+intensity=0.4
+saturation=1.7

--- a/plasma/desktoptheme/Materia/metadata.json
+++ b/plasma/desktoptheme/Materia/metadata.json
@@ -1,0 +1,19 @@
+{
+    "KPlugin": {
+        "Authors": [
+            {
+                "Email": "varlesh@gmail.com",
+                "Name": "Alexey Varfolomeev"
+            }
+        ],
+        "Category": "",
+        "Description": "Materia KDE customization",
+        "EnabledByDefault": true,
+        "Id": "Materia",
+        "License": "GPLv3",
+        "Name": "Materia",
+        "Version": "20220823",
+        "Website": "https://github.com/PapirusDevelopmentTeam/materia-kde"
+    },
+    "X-Plasma-APIVersion": "2"
+}

--- a/plasma/desktoptheme/Materia/plasmarc
+++ b/plasma/desktoptheme/Materia/plasmarc
@@ -1,0 +1,5 @@
+[ContrastEffect]
+enabled=false
+contrast=0.2
+intensity=0.4
+saturation=1.7

--- a/plasma/look-and-feel/com.github.varlesh.materia-dark/metadata.json
+++ b/plasma/look-and-feel/com.github.varlesh.materia-dark/metadata.json
@@ -1,0 +1,33 @@
+{
+    "KPackageStructure": "Plasma/LookAndFeel",
+    "KPlugin": {
+        "Authors": [
+            {
+                "Email": "varlesh@gmail.com",
+                "Name": "Alexey Varfolomeev"
+            }
+        ],
+        "Name": "Materia KDE Dark",
+        "Description": "Materia KDE customization",
+        "Id": "com.github.varlesh.materia-dark",
+        "Version": "20220823",
+        "Category": "",
+        "EnabledByDefault": true,
+        "License": "GPLv3",
+        "ServiceTypes": [
+            "Plasma/LookAndFeel"
+        ],
+        "Website": "https://github.com/PapirusDevelopmentTeam/materia-kde"
+    },
+    "Keywords": "Desktop;Workspace;Appearance;Look and Feel;Logout;Lock;Suspend;Shutdown;Hibernate;",
+    "X-Plasma-APIVersion": "2",
+    "X-KPackage-Dependencies": [
+        "kns://colorschemes.knsrc/api.kde-look.org/1229140",
+        "kns://plasma-themes.knsrc/api.kde-look.org/1229134",
+        "kns://aurorae.knsrc/api.kde-look.org/1229137",
+        "kns://icons.knsrc/api.kde-look.org/1166289",
+        "kns://xcursor.knsrc/api.kde-look.org/1346778",
+        "kns://wallpaper.knsrc/api.kde-look.org/1476107",
+        "kns://sddmtheme.knsrc/api.kde-look.org/1476117"
+    ]
+}

--- a/plasma/look-and-feel/com.github.varlesh.materia-dark/plasmarc
+++ b/plasma/look-and-feel/com.github.varlesh.materia-dark/plasmarc
@@ -1,0 +1,2 @@
+[Settings]
+FallbackTheme=breeze

--- a/plasma/look-and-feel/com.github.varlesh.materia-light/metadata.json
+++ b/plasma/look-and-feel/com.github.varlesh.materia-light/metadata.json
@@ -1,0 +1,32 @@
+{
+    "KPackageStructure": "Plasma/LookAndFeel",
+    "KPlugin": {
+        "Authors": [
+            {
+                "Email": "varlesh@gmail.com",
+                "Name": "Alexey Varfolomeev"
+            }
+        ],
+        "Name": "Materia KDE Light",
+        "Description": "Materia KDE customization",
+        "Id": "com.github.varlesh.materia-light",
+        "Version": "20220823",
+        "Category": "",
+        "EnabledByDefault": true,
+        "License": "GPLv3",
+        "ServiceTypes": [
+            "Plasma/LookAndFeel"
+        ],
+        "Website": "https://github.com/PapirusDevelopmentTeam/materia-kde"
+    },
+    "Keywords": "Desktop;Workspace;Appearance;Look and Feel;Logout;Lock;Suspend;Shutdown;Hibernate;",
+    "X-Plasma-APIVersion": "2",
+    "X-KPackage-Dependencies": [
+        "kns://colorschemes.knsrc/api.kde-look.org/1462605",
+        "kns://plasma-themes.knsrc/api.kde-look.org/1462611",
+        "kns://aurorae.knsrc/api.kde-look.org/1462610",
+        "kns://icons.knsrc/api.kde-look.org/1166289",
+        "kns://xcursor.knsrc/api.kde-look.org/1346778",
+        "kns://wallpaper.knsrc/api.kde-look.org/1462613"
+    ]
+}

--- a/plasma/look-and-feel/com.github.varlesh.materia-light/plasmarc
+++ b/plasma/look-and-feel/com.github.varlesh.materia-light/plasmarc
@@ -1,0 +1,2 @@
+[Settings]
+FallbackTheme=breeze

--- a/plasma/look-and-feel/com.github.varlesh.materia/metadata.json
+++ b/plasma/look-and-feel/com.github.varlesh.materia/metadata.json
@@ -1,0 +1,33 @@
+{
+    "KPackageStructure": "Plasma/LookAndFeel",
+    "KPlugin": {
+        "Authors": [
+            {
+                "Email": "varlesh@gmail.com",
+                "Name": "Alexey Varfolomeev"
+            }
+        ],
+        "Name": "Materia KDE",
+        "Description": "Materia KDE customization",
+        "Id": "com.github.varlesh.materia",
+        "Version": "20220823",
+        "Category": "",
+        "EnabledByDefault": true,
+        "License": "GPLv3",
+        "ServiceTypes": [
+            "Plasma/LookAndFeel"
+        ],
+        "Website": "https://github.com/PapirusDevelopmentTeam/materia-kde"
+    },
+    "Keywords": "Desktop;Workspace;Appearance;Look and Feel;Logout;Lock;Suspend;Shutdown;Hibernate;",
+    "X-Plasma-APIVersion": "2",
+    "X-KPackage-Dependencies": [
+        "kns://colorschemes.knsrc/api.kde-look.org/1462605",
+        "kns://plasma-themes.knsrc/api.kde-look.org/1462611",
+        "kns://aurorae.knsrc/api.kde-look.org/1462620",
+        "kns://icons.knsrc/api.kde-look.org/1166289",
+        "kns://xcursor.knsrc/api.kde-look.org/1346778",
+        "kns://wallpaper.knsrc/api.kde-look.org/1462613",
+        "kns://sddmtheme.knsrc/api.kde-look.org/1476113"
+    ]
+}

--- a/plasma/look-and-feel/com.github.varlesh.materia/plasmarc
+++ b/plasma/look-and-feel/com.github.varlesh.materia/plasmarc
@@ -1,0 +1,2 @@
+[Settings]
+FallbackTheme=breeze


### PR DESCRIPTION
KDE Plasma 6 now requires kpackage structure for theme packages, otherwise it will not display the corresponding theme entries in system settings.

This PR creates the metadata json files from original desktop files.

Note: Since Plasma 6 has a major API change, Materia's heavily customised lockscreen may not work well without a rewrite. 