### PR TITLE
(Yakuake) Fix black squares at rounded edges

### DIFF
--- a/yakuake/skins/materia-dark/title/background_left.svg
+++ b/yakuake/skins/materia-dark/title/background_left.svg
@@ -1,14 +1,53 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="7" height="38" version="1.1">
- <defs>
-  <linearGradient id="linearGradient831">
-   <stop style="stop-color:#000000;stop-opacity:1" offset="0"/>
-   <stop style="stop-color:#000000;stop-opacity:0" offset="1"/>
-  </linearGradient>
-  <radialGradient id="radialGradient843" cx="6" cy="305.444" r="3" fx="6" fy="305.444" gradientTransform="matrix(-2.3333334,8.2688579e-6,-1.2862565e-5,-2.6666453,21.003929,840.5138)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient831"/>
- </defs>
- <g transform="translate(0,4)">
-  <rect style="opacity:0.4;fill:url(#radialGradient843)" width="7" height="8" x="0" y="26"/>
-  <path style="fill:#272727" d="m 0,-4 v 30 c 0,1.662 1.338,3 3,3 H 7 V -4 Z"/>
-  <path style="opacity:0.1;fill:#ffffff" d="m 0,25 v 1 c 0,1.662 1.338,3 3,3 H 7 V 28 H 3 C 1.338,28 0,26.662 0,25 Z"/>
- </g>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="7"
+   height="38"
+   version="1.1"
+   id="svg3"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs2">
+    <linearGradient
+       id="linearGradient831">
+      <stop
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0"
+         id="stop1" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0.01137622;"
+         offset="1"
+         id="stop2" />
+    </linearGradient>
+    <radialGradient
+       id="radialGradient843"
+       cx="6"
+       cy="305.444"
+       r="3"
+       fx="6"
+       fy="305.444"
+       gradientTransform="matrix(-2.3333334,8.2688579e-6,-1.2862565e-5,-2.6666453,21.003929,840.5138)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient831" />
+  </defs>
+  <g
+     transform="translate(0,4)"
+     id="g3">
+    <rect
+       style="opacity:0.4;fill:url(#radialGradient843)"
+       width="7"
+       height="8"
+       x="0"
+       y="26"
+       id="rect2" />
+    <path
+       style="fill:#272727"
+       d="m 0,-4 v 30 c 0,1.662 1.338,3 3,3 H 7 V -4 Z"
+       id="path2" />
+    <path
+       style="opacity:0.1;fill:#ffffff"
+       d="m 0,25 v 1 c 0,1.662 1.338,3 3,3 H 7 V 28 H 3 C 1.338,28 0,26.662 0,25 Z"
+       id="path3" />
+  </g>
 </svg>

--- a/yakuake/skins/materia-dark/title/background_right.svg
+++ b/yakuake/skins/materia-dark/title/background_right.svg
@@ -1,14 +1,53 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="7" height="38" version="1.1">
- <defs>
-  <linearGradient id="linearGradient831">
-   <stop style="stop-color:#000000;stop-opacity:1" offset="0"/>
-   <stop style="stop-color:#000000;stop-opacity:0" offset="1"/>
-  </linearGradient>
-  <radialGradient id="radialGradient843" cx="6" cy="305.444" r="3" fx="6" fy="305.444" gradientTransform="matrix(-2.3333334,8.2688579e-6,-1.2862565e-5,-2.6666453,21.003929,840.5138)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient831"/>
- </defs>
- <g transform="matrix(-1,0,0,1,7,4)">
-  <rect style="opacity:0.4;fill:url(#radialGradient843)" width="7" height="8" x="0" y="26"/>
-  <path style="fill:#272727" d="m 0,-4 v 30 c 0,1.662 1.338,3 3,3 H 7 V -4 Z"/>
-  <path style="opacity:0.1;fill:#ffffff" d="m 0,25 v 1 c 0,1.662 1.338,3 3,3 H 7 V 28 H 3 C 1.338,28 0,26.662 0,25 Z"/>
- </g>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="7"
+   height="38"
+   version="1.1"
+   id="svg3"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs2">
+    <linearGradient
+       id="linearGradient831">
+      <stop
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0"
+         id="stop1" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0.00737404;"
+         offset="1"
+         id="stop2" />
+    </linearGradient>
+    <radialGradient
+       id="radialGradient843"
+       cx="6"
+       cy="305.444"
+       r="3"
+       fx="6"
+       fy="305.444"
+       gradientTransform="matrix(-2.3333334,8.2688579e-6,-1.2862565e-5,-2.6666453,21.003929,840.5138)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient831" />
+  </defs>
+  <g
+     transform="matrix(-1,0,0,1,7,4)"
+     id="g3">
+    <rect
+       style="opacity:0.4;fill:url(#radialGradient843)"
+       width="7"
+       height="8"
+       x="0"
+       y="26"
+       id="rect2" />
+    <path
+       style="fill:#272727"
+       d="m 0,-4 v 30 c 0,1.662 1.338,3 3,3 H 7 V -4 Z"
+       id="path2" />
+    <path
+       style="opacity:0.1;fill:#ffffff"
+       d="m 0,25 v 1 c 0,1.662 1.338,3 3,3 H 7 V 28 H 3 C 1.338,28 0,26.662 0,25 Z"
+       id="path3" />
+  </g>
 </svg>

--- a/yakuake/skins/materia-light/title/background_left.svg
+++ b/yakuake/skins/materia-light/title/background_left.svg
@@ -1,14 +1,53 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="7" height="38" version="1.1">
- <defs>
-  <linearGradient id="linearGradient831">
-   <stop style="stop-color:#000000;stop-opacity:1" offset="0"/>
-   <stop style="stop-color:#000000;stop-opacity:0" offset="1"/>
-  </linearGradient>
-  <radialGradient id="radialGradient843" cx="6" cy="305.444" r="3" fx="6" fy="305.444" gradientTransform="matrix(-2.3333334,8.2688579e-6,-1.2862565e-5,-2.6666453,21.003929,840.5138)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient831"/>
- </defs>
- <g transform="translate(0,4)">
-  <rect style="opacity:0.4;fill:url(#radialGradient843)" width="7" height="8" x="0" y="26"/>
-  <path style="fill:#f0f0f0" d="m 0,-4 v 30 c 0,1.662 1.338,3 3,3 H 7 V -4 Z"/>
-  <path style="opacity:0.3;fill:#ffffff" d="m 0,25 v 1 c 0,1.662 1.338,3 3,3 H 7 V 28 H 3 C 1.338,28 0,26.662 0,25 Z"/>
- </g>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="7"
+   height="38"
+   version="1.1"
+   id="svg3"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs2">
+    <linearGradient
+       id="linearGradient831">
+      <stop
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0"
+         id="stop1" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0.01;"
+         offset="1"
+         id="stop2" />
+    </linearGradient>
+    <radialGradient
+       id="radialGradient843"
+       cx="6"
+       cy="305.444"
+       r="3"
+       fx="6"
+       fy="305.444"
+       gradientTransform="matrix(-2.3333334,8.2688579e-6,-1.2862565e-5,-2.6666453,21.003929,840.5138)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient831" />
+  </defs>
+  <g
+     transform="translate(0,4)"
+     id="g3">
+    <rect
+       style="opacity:0.4;fill:url(#radialGradient843)"
+       width="7"
+       height="8"
+       x="0"
+       y="26"
+       id="rect2" />
+    <path
+       style="fill:#f0f0f0"
+       d="m 0,-4 v 30 c 0,1.662 1.338,3 3,3 H 7 V -4 Z"
+       id="path2" />
+    <path
+       style="opacity:0.3;fill:#ffffff"
+       d="m 0,25 v 1 c 0,1.662 1.338,3 3,3 H 7 V 28 H 3 C 1.338,28 0,26.662 0,25 Z"
+       id="path3" />
+  </g>
 </svg>

--- a/yakuake/skins/materia-light/title/background_right.svg
+++ b/yakuake/skins/materia-light/title/background_right.svg
@@ -1,14 +1,53 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="7" height="38" version="1.1">
- <defs>
-  <linearGradient id="linearGradient831">
-   <stop style="stop-color:#000000;stop-opacity:1" offset="0"/>
-   <stop style="stop-color:#000000;stop-opacity:0" offset="1"/>
-  </linearGradient>
-  <radialGradient id="radialGradient843" cx="6" cy="305.444" r="3" fx="6" fy="305.444" gradientTransform="matrix(-2.3333334,8.2688579e-6,-1.2862565e-5,-2.6666453,21.003929,840.5138)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient831"/>
- </defs>
- <g transform="matrix(-1,0,0,1,7,4)">
-  <rect style="opacity:0.4;fill:url(#radialGradient843)" width="7" height="8" x="0" y="26"/>
-  <path style="fill:#f0f0f0" d="m 0,-4 v 30 c 0,1.662 1.338,3 3,3 H 7 V -4 Z"/>
-  <path style="opacity:0.3;fill:#ffffff" d="m 0,25 v 1 c 0,1.662 1.338,3 3,3 H 7 V 28 H 3 C 1.338,28 0,26.662 0,25 Z"/>
- </g>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="7"
+   height="38"
+   version="1.1"
+   id="svg3"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs2">
+    <linearGradient
+       id="linearGradient831">
+      <stop
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0"
+         id="stop1" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0.01;"
+         offset="1"
+         id="stop2" />
+    </linearGradient>
+    <radialGradient
+       id="radialGradient843"
+       cx="6"
+       cy="305.444"
+       r="3"
+       fx="6"
+       fy="305.444"
+       gradientTransform="matrix(-2.3333334,8.2688579e-6,-1.2862565e-5,-2.6666453,21.003929,840.5138)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient831" />
+  </defs>
+  <g
+     transform="matrix(-1,0,0,1,7,4)"
+     id="g3">
+    <rect
+       style="opacity:0.4;fill:url(#radialGradient843)"
+       width="7"
+       height="8"
+       x="0"
+       y="26"
+       id="rect2" />
+    <path
+       style="fill:#f0f0f0"
+       d="m 0,-4 v 30 c 0,1.662 1.338,3 3,3 H 7 V -4 Z"
+       id="path2" />
+    <path
+       style="opacity:0.3;fill:#ffffff"
+       d="m 0,25 v 1 c 0,1.662 1.338,3 3,3 H 7 V 28 H 3 C 1.338,28 0,26.662 0,25 Z"
+       id="path3" />
+  </g>
 </svg>


### PR DESCRIPTION
This PR aims to fix the black artifacts near the rounded edges of both light and dark versions of the theme :

![Copie d'écran_20241001_140245](https://github.com/user-attachments/assets/b84c5812-02c0-493d-b448-ce5d27ef5015)

This uses a pretty gross hack, consisting of setting the shadow's ending opacity to 1 percent instead of zero.

There's no noticable changes to my eye (except for the now gone black edges) but feedback on other setups is welcome :

![Copie d'écran_20241001_143541](https://github.com/user-attachments/assets/f6a48a61-0ff8-42b3-85f3-462065b35db4)

This bug happened to me on Plasma 6.1.5 with Intel graphics.
I am not aware if it could be fixed by porting the theme to Plasma 6, or by using different drivers.

Assuming it's gonna take a while only to receive feedback on this, porting is not gonna happen in a while or ever, thus the aformentionned hack :sweat_smile:  